### PR TITLE
Add feature 'ord_max_min' crate attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(ord_max_min)] 
 //! A concurrent work-stealing deque.
 //!
 //! The data structure can be thought of as a dynamically growable and shrinkable buffer that has


### PR DESCRIPTION
Rust complains otherwise, e.g.:

```
error: use of unstable library feature 'ord_max_min' (see issue #25663)
   --> /home/james/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-deque-0.3.0/src/lib.rs:667:27
    |
667 |         b.wrapping_sub(t).max(0) as usize
    |                           ^^^
    |
    = help: add #![feature(ord_max_min)] to the crate attributes to enable

error: aborting due to previous error

error: Could not compile `crossbeam-deque`.
```