### PR TITLE
Add unstable feature: ord_max_min

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 //! [Deque::steal]: struct.Deque.html#method.steal
 //! [Stealer::steal]: struct.Stealer.html#method.steal
 
+#![feature(ord_max_min)]
 extern crate crossbeam_epoch as epoch;
 extern crate crossbeam_utils as utils;
 


### PR DESCRIPTION
While building crossbeam-deque, I encountered the following message:
![image](https://user-images.githubusercontent.com/6235760/39407430-4d78a32c-4bc6-11e8-8770-40fbf5c25225.png)

Solved this by adding the unstable feature: ord_max_min